### PR TITLE
Use same import of light and dark theme as in Sun Valley.

### DIFF
--- a/azure.tcl
+++ b/azure.tcl
@@ -1,7 +1,7 @@
 # Copyright © 2021 rdbende <rdbende@gmail.com>
 
-source theme/light.tcl
-source theme/dark.tcl
+source [file join [file dirname [info script]] theme light.tcl]
+source [file join [file dirname [info script]] theme dark.tcl]
 
 option add *tearOff 0
 


### PR DESCRIPTION
Dear rdbende,

this new method of switching themes works really great. I had problems using the Azure theme, though, because it could not find the light.tcl and dark.tcl. I got the following error:
```
top.tk.call('source', bundle_dir + '/themes/azure-2.0/azure.tcl')
_tkinter.TclError: couldn't read file "theme/light.tcl": no such file or directory
```  
So I changed the import of light.tcl and dark.tcl as in your Sun Valley scheme and then it works fine.

Done on macOS 10.15, Python 3.8.9.

Kind regards,
Matthias