### PR TITLE
Update dark.tcl

### DIFF
--- a/theme/dark.tcl
+++ b/theme/dark.tcl
@@ -289,8 +289,8 @@ namespace eval ttk::theme::azure-dark {
             [list $I(off-basic) \
                 {selected disabled} $I(on-basic) \
                 disabled $I(off-basic) \
-                {pressed selected} $I(on-basic) \
-                {active selected} $I(on-basic) \
+                {pressed selected} $I(on-accent) \
+                {active selected} $I(on-accent) \
                 selected $I(on-accent) \
                 {pressed !selected} $I(off-basic) \
                 active $I(off-basic) \


### PR DESCRIPTION
Hovering over the switch (when it was on) looks the same as when it was off. This fixes that. Now you the switch doesn't change color when are hovering over it, but it is better overall.