### PR TITLE
Fix focus render on AccentButton

### DIFF
--- a/theme/dark.tcl
+++ b/theme/dark.tcl
@@ -206,6 +206,7 @@ namespace eval ttk::theme::azure-dark {
                 pressed $I(rect-basic) \
                 selected $I(rect-basic) \
                 active $I(button-hover) \
+                focus $I(button-hover) \
             ] -border 4 -sticky ewns
 
         # Toolbutton
@@ -264,6 +265,7 @@ namespace eval ttk::theme::azure-dark {
                 pressed $I(rect-accent) \
                 selected $I(rect-accent) \
                 active $I(rect-accent-hover) \
+                focus $I(rect-accent-hover) \
             ] -border 4 -sticky ewns
 
         # Checkbutton

--- a/theme/light.tcl
+++ b/theme/light.tcl
@@ -206,6 +206,7 @@ namespace eval ttk::theme::azure-light {
                 selected $I(rect-basic) \
                 pressed $I(rect-basic) \
                 active $I(button-hover) \
+                focus $I(button-hover) \
             ] -border 4 -sticky ewns
 
         # Toolbutton
@@ -264,6 +265,7 @@ namespace eval ttk::theme::azure-light {
                 selected $I(rect-accent) \
                 pressed $I(rect-accent) \
                 active $I(rect-accent-hover) \
+                focus $I(rect-accent-hover) \
             ] -border 4 -sticky ewns
 
         # Checkbutton


### PR DESCRIPTION
The AccentButton has no focus frame when navigated with Tab key, so fix this.